### PR TITLE
fix ImmediateLoad use

### DIFF
--- a/Models/Consumable.cs
+++ b/Models/Consumable.cs
@@ -65,14 +65,13 @@ namespace Munchies.Models {
 				Texture = ModContent.Request<Texture2D>(texturePath);
 				UsingMissingTexture = false;
 			} else {
-				//AssetDimensions = (6, 16);
-				Texture = ModContent.Request<Texture2D>("Terraria/Images/UI/UI_quickicon1", mode: AssetRequestMode.ImmediateLoad);
+				Texture = ModContent.Request<Texture2D>("Terraria/Images/UI/UI_quickicon1");
 				UsingMissingTexture = true;
 			}
 		}
 
 		private void SetTexture(int vanillaItemId) {
-			Texture = ModContent.Request<Texture2D>($"Terraria/Images/Item_{vanillaItemId}", mode: AssetRequestMode.ImmediateLoad);
+			Texture = ModContent.Request<Texture2D>($"Terraria/Images/Item_{vanillaItemId}");
 			UsingMissingTexture = false;
 		}
 

--- a/Models/ConsumableMod.cs
+++ b/Models/ConsumableMod.cs
@@ -7,13 +7,11 @@ using Terraria.ModLoader;
 namespace Munchies.Models {
 	public class ConsumableMod {
 		public string ModTabName;
-		//public string ModTabTexturePath = modTabTexturePath;
 		public Asset<Texture2D> ModTabTexture;
 		public bool UsingMissingTexture;
 
 		public ConsumableMod(string modTabName, string modTabTexturePath) {
 			ModTabName = modTabName;
-			//ModTabTexture = ModContent.Request<Texture2D>(modTabTexturePath);
 			SetTextureForVanilla(modTabTexturePath);
 		}
 
@@ -24,7 +22,7 @@ namespace Munchies.Models {
 
 		private void SetTextureForExternalMod(Mod mod) {
 			if (mod.HasAsset("icon_small")) {
-				Asset<Texture2D> texture = mod.Assets.Request<Texture2D>("icon_small");
+				Asset<Texture2D> texture = mod.Assets.Request<Texture2D>("icon_small", AssetRequestMode.ImmediateLoad); //Dimensions checked for parity with tml so it needs Immediate
 				if (texture.Size() == new Vector2(30)) {
 					ModTabTexture = texture;
 					UsingMissingTexture = false;


### PR DESCRIPTION
Since UI now loads deferred from data initialization, many ImmediateLoad aren't needed. One was added due to still requiring to check dimensions